### PR TITLE
Possible fix for merge-to-awkward-record-array when numpy object array present in the dataframe

### DIFF
--- a/src/awkward_pandas/__init__.py
+++ b/src/awkward_pandas/__init__.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import awkward_pandas.accessor  # noqa
 from awkward_pandas.array import AwkwardExtensionArray, merge
 from awkward_pandas.dtype import AwkwardDtype
-from awkward_pandas.io import read_parquet
+from awkward_pandas.io import read_json, read_parquet
 from awkward_pandas.version import version as __version__  # noqa
 
-__all__ = ("AwkwardDtype", "AwkwardExtensionArray", "read_parquet", "merge")
+__all__ = (
+    "AwkwardDtype",
+    "AwkwardExtensionArray",
+    "merge",
+    "read_parquet",
+    "read_json",
+)

--- a/src/awkward_pandas/accessor.py
+++ b/src/awkward_pandas/accessor.py
@@ -65,7 +65,7 @@ class AwkwardAccessor:
         else:
             return pd.Series(ak.to_numpy(data))
 
-    def to_columns(self, cull=True):
+    def to_columns(self, cull=True, extract_all=False):
         s = self._obj
         fields = self.arr._data.fields
         out = {}
@@ -73,8 +73,11 @@ class AwkwardAccessor:
             try:
                 out[field] = s.ak[field].ak.to_column()
             except Exception:
-                pass
-        if cull:
+                if extract_all:
+                    out[field] = s.ak[field]
+        if cull and extract_all:
+            pass
+        elif cull:
             out[s.name] = s.ak[[_ for _ in fields if _ not in out]]
         else:
             out[s.name] = s

--- a/src/awkward_pandas/array.py
+++ b/src/awkward_pandas/array.py
@@ -193,7 +193,7 @@ def merge(dataframe, name=None):
         elif dataframe[c].dtype == "string[pyarrow]":
             out[c] = ak.from_arrow(dataframe[c].values._data)
         elif dataframe[c].dtype == "object":
-            out[c] = list(dataframe[c])
+            out[c] = iter(dataframe[c])
         else:
             out[c] = dataframe[c].values
     return pd.Series(AwkwardExtensionArray(ak.Array(out)), name=name)

--- a/src/awkward_pandas/array.py
+++ b/src/awkward_pandas/array.py
@@ -192,6 +192,8 @@ def merge(dataframe, name=None):
             out[c] = dataframe[c].values._data
         elif dataframe[c].dtype == "string[pyarrow]":
             out[c] = ak.from_arrow(dataframe[c].values._data)
+        elif dataframe[c].dtype == "object":
+            out[c] = list(dataframe[c])
         else:
             out[c] = dataframe[c].values
     return pd.Series(AwkwardExtensionArray(ak.Array(out)), name=name)

--- a/src/awkward_pandas/array.py
+++ b/src/awkward_pandas/array.py
@@ -171,9 +171,6 @@ class AwkwardExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 AwkwardExtensionArray._add_arithmetic_ops()
 AwkwardExtensionArray._add_comparison_ops()
 
-# for k in ["mean", "var", "std", "sum", "prod"]:
-#     setattr(AwkwardExtensionArray, k, getattr(ak, k))
-
 
 def merge(dataframe, name=None):
     """Create a single awkward series by merging the columns of a dataframe.

--- a/src/awkward_pandas/io.py
+++ b/src/awkward_pandas/io.py
@@ -4,9 +4,33 @@ import pandas as pd
 import awkward_pandas
 
 
-def read_parquet(url, extract=True, **kwargs):
+def read_parquet(
+    url,
+    extract=True,
+    root_name="awkward",
+    extract_all=False,
+    **kwargs,
+):
     ds = ak.from_parquet(url, **kwargs)
-    s = pd.Series(awkward_pandas.AwkwardExtensionArray(ds))
-    if extract is False:
-        return s
-    return s.ak.to_columns(cull=True)
+    s = pd.Series(awkward_pandas.AwkwardExtensionArray(ds), name=root_name)
+    if extract:
+        return s.ak.to_columns(cull=True, extract_all=extract_all)
+    return s
+
+
+def read_json(
+    source,
+    extract=True,
+    root_name="awkward",
+    extract_all=False,
+    **kwargs,
+):
+    ds = ak.from_json(
+        source,
+        line_delimited=True,
+        **kwargs,
+    )
+    s = pd.Series(awkward_pandas.AwkwardExtensionArray(ds), name=root_name)
+    if extract:
+        return s.ak.to_columns(cull=True, extract_all=extract_all)
+    return s

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -4,7 +4,6 @@ import pytest
 from awkward_pandas import AwkwardExtensionArray, merge
 
 
-@pytest.mark.xfail(reason="awkward cannot convert numpy array object dtype")
 def test_merge_no_ak():
     df = pd.DataFrame(
         {

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pytest
 
 from awkward_pandas import AwkwardExtensionArray, merge
 


### PR DESCRIPTION
Going from `awkward==1.10.1` to https://github.com/scikit-hep/awkward/commit/f3a94128d472f71bc3ba45c709ebc45e26c93bd6 (current `HEAD` of `main`) we can no longer do the following:

```python
In [1]: import pandas as pd

In [2]: import awkward._v2 as ak

In [3]: df = pd.DataFrame({"a": ["one", "two"]})

In [4]: ak.Array({"a": df.a.values})
Out[4]: <Array [{a: 'one'}, {a: 'two'}] type='2 * {a: string}'>

In [5]: 

In [5]: import awkward as ak1

In [6]: ak1.__version__
Out[6]: '1.10.1'
```




<details open>
<summary>doing the same on the latest commit (long traceback)</summary>
<br>

```python
In [1]: import awkward as ak

In [2]: ak.__version__
Out[2]: '2.0.0rc1'

In [3]: import pandas as pd

In [4]: df = pd.DataFrame({"a": ["one", "two"]})

In [5]: ak.Array({"a": df.a.values})
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In [5], line 1
----> 1 ak.Array({"a": df.a.values})

File ~/.pyenv/versions/3.10.7/envs/dev/lib/python3.10/site-packages/awkward/highlevel.py:218, in Array.__init__(self, data, behavior, with_name, check_valid, backend)
    216 for k, v in data.items():
    217     fields.append(k)
--> 218     contents.append(Array(v).layout)
    219     if length is None:
    220         length = len(contents[-1])

File ~/.pyenv/versions/3.10.7/envs/dev/lib/python3.10/site-packages/awkward/highlevel.py:201, in Array.__init__(self, data, behavior, with_name, check_valid, backend)
    198     behavior = ak._util.behavior_of(data, behavior=behavior)
    200 elif numpy.is_own_array(data):
--> 201     layout = ak.operations.from_numpy(data, highlevel=False)
    203 elif ak.nplikes.Cupy.is_own_array(data):
    204     layout = ak.operations.from_cupy(data, highlevel=False)

File ~/.pyenv/versions/3.10.7/envs/dev/lib/python3.10/site-packages/awkward/operations/ak_from_numpy.py:50, in from_numpy(array, regulararray, recordarray, highlevel, behavior)
      9 """
     10 Args:
     11     array (np.ndarray): The NumPy array to convert into an Awkward Array.
   (...)
     38 See also #ak.to_numpy and #ak.from_cupy.
     39 """
     40 with ak._errors.OperationErrorContext(
     41     "ak.from_numpy",
     42     dict(
   (...)
     48     ),
     49 ):
---> 50     return ak._util.from_arraylib(
     51         array, regulararray, recordarray, highlevel, behavior
     52     )

File ~/.pyenv/versions/3.10.7/envs/dev/lib/python3.10/site-packages/awkward/_util.py:709, in from_arraylib(array, regulararray, recordarray, highlevel, behavior)
    706     mask = None
    708 if not recordarray or array.dtype.names is None:
--> 709     layout = recurse(array, mask)
    711 else:
    712     contents = []

File ~/.pyenv/versions/3.10.7/envs/dev/lib/python3.10/site-packages/awkward/_util.py:670, in from_arraylib.<locals>.recurse(array, mask)
    665         data = ak.contents.RegularArray(
    666             data, array.shape[i], array.shape[i - 1]
    667         )
    669 else:
--> 670     data = ak.contents.NumpyArray(array)
    672 if mask is None:
    673     return data

File ~/.pyenv/versions/3.10.7/envs/dev/lib/python3.10/site-packages/awkward/contents/numpyarray.py:49, in NumpyArray.__init__(self, data, identifier, parameters, nplike)
     46 self._data = nplike.asarray(data)
     48 if not isinstance(nplike, ak.nplikes.Jax):
---> 49     ak.types.numpytype.dtype_to_primitive(self._data.dtype)
     50 if len(self._data.shape) == 0:
     51     raise ak._errors.wrap_error(
     52         TypeError(
     53             "{} 'data' must be an array, not a scalar: {}".format(
   (...)
     56         )
     57     )

File ~/.pyenv/versions/3.10.7/envs/dev/lib/python3.10/site-packages/awkward/types/numpytype.py:47, in dtype_to_primitive(dtype)
     45 out = _dtype_to_primitive_dict.get(dtype)
     46 if out is None:
---> 47     raise ak._errors.wrap_error(
     48         TypeError(
     49             "unsupported dtype: {}. Must be one of\n\n    {}\n\nor a "
     50             "datetime64/timedelta64 with units (e.g. 'datetime64[15us]')".format(
     51                 repr(dtype), ", ".join(_primitive_to_dtype_dict)
     52             )
     53         )
     54     )
     55 return out

TypeError: while calling (from /Users/ddavis/.pyenv/versions/3.10.7/envs/dev/lib/python3.10/site-packages/awkward/highlevel.py, line 201)

    ak.from_numpy(
        array = numpy.ndarray(['one' 'two'])
        regulararray = False
        recordarray = True
        highlevel = False
        behavior = None
    )

Error details: unsupported dtype: dtype('O'). Must be one of

    bool, int8, uint8, int16, uint16, int32, uint32, int64, uint64, float32, float64, complex64, complex128, datetime64, timedelta64, float16

or a datetime64/timedelta64 with units (e.g. 'datetime64[15us]')
```

</details>

this PR just wraps the object arrays in a Python `iter` call. It works but I'm wondering if there is a better solution. cc @martindurant @jpivarski