### PR TITLE
Fix DataFrame to_parquet serialization

### DIFF
--- a/src/awkward_pandas/array.py
+++ b/src/awkward_pandas/array.py
@@ -145,10 +145,10 @@ class AwkwardExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         return np.asarray(self._data, dtype=dtype)
 
-    def __arrow_array__(self):
+    def __arrow_array__(self, type=None):
         import pyarrow as pa
 
-        return pa.chunked_array(ak.to_arrow(self._data))
+        return pa.chunked_array(ak.to_arrow(self._data), type=type)
 
     def tolist(self) -> list:
         return self._data.tolist()

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -40,10 +40,12 @@ def test_merge_one_ak():
 
 
 def test_parquet_roundtrip(tmp_path):
-    df = pd.DataFrame({
-        "a": [1, 2, 3, 4, 5],
-        "b": pd.Series(AwkwardExtensionArray([[1, 2, 3], [5], [6, 7], [], None])),
-    })
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5],
+            "b": pd.Series(AwkwardExtensionArray([[1, 2, 3], [5], [6, 7], [], None])),
+        }
+    )
 
     assert df["b"].dtype == "awkward"
 

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
 from awkward_pandas import AwkwardExtensionArray, merge
 
@@ -38,4 +39,16 @@ def test_merge_one_ak():
     assert arr["b"].tolist() == [[1, 2, 3], [5], [6, 7]]
 
 
-# def test_merge_all_ak:
+def test_parquet_roundtrip(tmp_path):
+    df = pd.DataFrame({
+        "a": [1, 2, 3, 4, 5],
+        "b": pd.Series(AwkwardExtensionArray([[1, 2, 3], [5], [6, 7], [], None])),
+    })
+
+    assert df["b"].dtype == "awkward"
+
+    path = tmp_path / "output.parquet"
+    df.to_parquet(path, engine="pyarrow")
+    result = pd.read_parquet(path)
+
+    assert_frame_equal(df, result)


### PR DESCRIPTION
References:
- https://arrow.apache.org/docs/python/extending_types.html#controlling-conversion-to-pyarrow-array-with-the-arrow-array-protocol
- https://pandas.pydata.org/docs/development/extending.html#compatibility-with-apache-arrow